### PR TITLE
Support store method

### DIFF
--- a/lib/zipstream.rb
+++ b/lib/zipstream.rb
@@ -13,12 +13,17 @@ class Zipstream
   end
 
   def write name, data, options={}
-    # Fails without specifying the window bits (odd!)
-    deflater = Zlib::Deflate.new Zlib::BEST_COMPRESSION, -Zlib::MAX_WBITS
-    zdata = deflater.deflate data, Zlib::FINISH
-    deflater.close
+    if options[:method] == :store
+      zdata = data
+      method = 0x00
+    else
+      # Fails without specifying the window bits (odd!)
+      deflater = Zlib::Deflate.new Zlib::BEST_COMPRESSION, -Zlib::MAX_WBITS
+      zdata = deflater.deflate data, Zlib::FINISH
+      deflater.close
+      method = 0x08
+    end
 
-    method = 0x08
     timestamp = dostime options[:datetime] || DateTime.now
     crc = Zlib.crc32 data
     zdata_length = zdata.length

--- a/spec/zipstream_spec.rb
+++ b/spec/zipstream_spec.rb
@@ -30,4 +30,30 @@ describe Zipstream do
       license.get_input_stream.read.should == "Copyright (c) 2012 Me"
     end
   end
+  
+  it "should support setting compression method" do
+    File.open(path, 'w') do |f|
+      zip = Zipstream.new(f)
+      zip.write "deflated.txt", "deflated file", :method => :deflate
+      zip.write "stored.txt", "stored file", :method => :store
+      zip.write "default.txt", "default method"
+      zip.close
+    end
+
+    Zip::ZipFile.open(path, "r") do |zip|
+      zip.size.should == 3
+
+      deflated = zip.find_entry("deflated.txt")
+      deflated.get_input_stream.read.should == "deflated file"
+      deflated.compression_method.should == Zip::ZipEntry::DEFLATED
+
+      stored = zip.find_entry("stored.txt")
+      stored.get_input_stream.read.should == "stored file"
+      stored.compression_method.should == Zip::ZipEntry::STORED
+
+      default = zip.find_entry("default.txt")
+      default.get_input_stream.read.should == "default method"
+      default.compression_method.should == Zip::ZipEntry::DEFLATED
+    end
+  end
 end


### PR DESCRIPTION
This pull request implements a `:method` option so you can specify you want to `:store` a file (instead of `:deflate` it, which was the previous behavior, and still the default one):

``` ruby
zip.write 'file1.txt', 'this file will be stored', :method => :store
zip.write 'file2.txt', 'this file will be deflated', :method => :deflate
zip.write 'file3.txt', 'this file will be deflated too'
```

Storing a file instead of deflating it:

1) is more efficient in terms of space for very small files
2) saves you a lot of CPU work in exchange of a little space with some kind of big already compressed files
