### PR TITLE
Issue with version needed to extract

### DIFF
--- a/lib/zipstream.rb
+++ b/lib/zipstream.rb
@@ -32,9 +32,9 @@ class Zipstream
       # central file header signature
       0x02014b50,
       # version made by
-      (6 << 8) + 3,
+      0x0A,
       # version needed to extract
-      (6 << 8) + 3,
+      0x0A,
       # general purpose bit flag
       0x00,
       # compresion method (deflate or store)
@@ -69,7 +69,7 @@ class Zipstream
       # local file header signature
       0x04034b50,
       # version needed to extract
-      (6 << 8) + 3,
+      0x0A,
       # general purpose bit flag
       0x00,
       # compresion method (deflate or store)


### PR DESCRIPTION
This is more an issue than a pull request, since the patch attached is more some clue about the problem I'm having than a proposed final solution to it.

I was having troubles with files generated by zipstream. They seem :ok: (and probably are), but the MacOSX bult-in extractor wasn't working with them. Instead of extracting the files, it extracts only one file with name `file.zip.cpgz`. Of course this seems to be a problem not in the zip file but in the extractor (since that file works perfectly :ok: with every other extractor I tried, for example the `unzip` command line tool), but it was still annoying.

Anyway, there was something funny going on, as the `file` command line tool shows (file.zip is a file generated with zipstream, file2.zip another one with the same contents generated by the `zip` command line tool):

```
$ file tests/*.zip

tests/file.zip:  data
tests/file2.zip: Zip archive data, at least v2.0 to extract
```

Armed with [the zip spec](http://www.pkware.com/documents/casestudies/APPNOTE.TXT) and [a hex editor](http://ridiculousfish.com/hexfiend/) I tinkered a bit with the different values I observed in both files and noticed the problem was in the bytes used to specify the needed version, and even managed to manually _fix_ the file. As you can see in the patch, I changed the original value to the default one (1.0) and it now works. Of course that's not the fix since I don't really know which version of the spec should be referenced.

But now:

```
$ file tests/*.zip

tests/file.zip:  Zip archive data, at least v1.0 to extract
tests/file2.zip: Zip archive data, at least v2.0 to extract
```

And the extraction works as expected.

P.S.: In case you want to “reproduce” this, I'm using MacOSX 10.7.4. I don't know which other versions of the extractor show this problem too.
