### PR TITLE
Fix Mime::Type warning for Rails > 3.2

### DIFF
--- a/lib/zipstream/railtie.rb
+++ b/lib/zipstream/railtie.rb
@@ -2,7 +2,9 @@
 class Zipstream::Railtie < Rails::Railtie
   initializer "zipstream" do
     # Register Mime::ZIP
-    Mime::Type.register "application/zip", :zip
+    unless Mime::Type.lookup "application/zip"
+      Mime::Type.register "application/zip", :zip
+    end
 
     # Mark our template handler as rendering zip files
     Zipstream::Railtie::Template.default_format = Mime::ZIP


### PR DESCRIPTION
When using zipstream with Rails 3.2 or above, a warning appears in the logs:

> /Users/alisdair/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/actionpack-3.2.13/lib/action_dispatch/http/mime_type.rb:102: warning: already initialized constant ZIP

[As of Rails 3.2](https://github.com/rails/rails/commit/d73269ba53992d8a01e5721aad3d23bc2b11dc4f), the "application/zip" mime type is already registered.

The pull request checks for the existence of the mime type before registering, which fixes the warning and should retain compatibility with Rails 3.1.
